### PR TITLE
Refine option toggles and remove unused metadata stripping

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,8 @@
   aside{border-right:1px solid var(--border); background:var(--panel); padding:12px; overflow:auto}
   .section-title{font-size:12px; text-transform:uppercase; letter-spacing:.14em; color:var(--muted); margin:12px 0 8px}
   .row{display:flex; gap:8px; align-items:center; flex-wrap:wrap}
+  label.row{flex-wrap:nowrap}
+  label.row span{flex:1}
   .field{display:grid; gap:6px; margin:10px 0}
   input[type="text"], input[type="file"], textarea, select{
     width:100%; padding:10px 12px; border:1px solid var(--border); border-radius:10px; background:var(--code-bg); color:var(--text)
@@ -89,8 +91,8 @@
   .kvlist{display:grid; grid-template-columns:1fr 1fr auto; gap:6px; align-items:center}
   .kvitem{display:contents}
   .delbtn{appearance:none; border:1px solid var(--border); background:#2a1114; color:#ff9aa4; border-radius:8px; padding:6px 8px; cursor:pointer}
-  label.row input[type="checkbox"]{appearance:none;width:36px;height:20px;border-radius:999px;background:var(--border);position:relative;cursor:pointer;transition:background .2s}
-  label.row input[type="checkbox"]::before{content:'';position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:#fff;border:1px solid var(--border);transition:transform .2s;box-shadow:0 1px 3px rgba(0,0,0,.3)}
+  label.row input[type="checkbox"]{appearance:none;width:36px;height:20px;border-radius:999px;background:var(--border);position:relative;cursor:pointer;transition:background .2s;margin-left:auto}
+  label.row input[type="checkbox"]::before{content:'';position:absolute;top:1px;left:1px;width:16px;height:16px;border-radius:50%;background:#fff;border:1px solid var(--border);transition:transform .2s;box-shadow:0 1px 3px rgba(0,0,0,.3)}
   label.row input[type="checkbox"]:checked{background:linear-gradient(135deg,var(--accent),var(--accent2))}
   label.row input[type="checkbox"]:checked::before{transform:translateX(16px)}
 </style>
@@ -143,13 +145,12 @@ applies_to: prescribed_npo
       <div id="blockBar" class="bar" aria-label="Block bar"></div>
 
       <div class="hr"></div>
-      <div class="section-title">Options</div>
-      <div class="field">
-        <label class="row"><input type="checkbox" id="stripExisting" checked /> <span>Strip existing metadata comment blocks on generate</span></label>
-        <label class="row"><input type="checkbox" id="detectExisting" checked /> <span>Auto-detect existing blocks when loading</span></label>
-        <label class="row"><input type="checkbox" id="blankAround" /> <span>Add a blank line after inserted blocks</span></label>
-        <label class="row"><input type="checkbox" id="strongerHighlights" checked /> <span>Use stronger region highlights</span></label>
-      </div>
+        <div class="section-title">Options</div>
+        <div class="field">
+          <label class="row"><span>Auto-detect existing blocks when loading</span><input type="checkbox" id="detectExisting" checked /></label>
+          <label class="row"><span>Add a blank line after inserted blocks</span><input type="checkbox" id="blankAround" /></label>
+          <label class="row"><span>Use stronger region highlights</span><input type="checkbox" id="strongerHighlights" checked /></label>
+        </div>
 
       <div class="hr"></div>
       <div class="section-title">Shortcuts</div>
@@ -199,10 +200,10 @@ applies_to: prescribed_npo
   const els = {
     lines: qs('#lines'), status: qs('#status'), fileInput: qs('#fileInput'), loadBtn: qs('#loadBtn'),
     generateBtn: qs('#generateBtn'), downloadBtn: qs('#downloadBtn'), resetBtn: qs('#resetBtn'),
-    blockName: qs('#blockName'), kvList: qs('#kvList'), addKVBtn: qs('#addKVBtn'),
-    createBlockBtn: qs('#createBlockBtn'), clearPairsBtn: qs('#clearPairsBtn'), blockBar: qs('#blockBar'),
-    stripExisting: qs('#stripExisting'), detectExisting: qs('#detectExisting'), blankAround: qs('#blankAround'),
-    strongerHighlights: qs('#strongerHighlights'), loadDemo: qs('#loadDemo'),
+      blockName: qs('#blockName'), kvList: qs('#kvList'), addKVBtn: qs('#addKVBtn'),
+      createBlockBtn: qs('#createBlockBtn'), clearPairsBtn: qs('#clearPairsBtn'), blockBar: qs('#blockBar'),
+      detectExisting: qs('#detectExisting'), blankAround: qs('#blankAround'),
+      strongerHighlights: qs('#strongerHighlights'), loadDemo: qs('#loadDemo'),
   };
 
   // Events
@@ -451,7 +452,7 @@ applies_to: prescribed_npo
 
   function generateOutput(){
     if (!originalText){ toast('Load a Markdown file first.'); return; }
-    const baseLines = document.getElementById('stripExisting').checked ? parseAndStripMetadataBlocks([...bodyLines]).lines : [...bodyLines];
+    const baseLines = [...bodyLines];
 
     const markersByLine = new Map(assignments.map(a => [a.line, a.blockId]));
     const outLines = [];


### PR DESCRIPTION
## Summary
- Align toggle sliders and keep their labels on one line for a cleaner options layout
- Remove “strip existing metadata” control and related logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9e364d248332bac8051182b7ae30