### PR TITLE
Render loaded Markdown as HTML and remove preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,9 +95,6 @@
   label.row input[type="checkbox"]::before{content:'';position:absolute;top:1px;left:1px;width:16px;height:16px;border-radius:50%;background:#fff;border:1px solid var(--border);transition:transform .2s;box-shadow:0 1px 3px rgba(0,0,0,.3)}
   label.row input[type="checkbox"]:checked{background:linear-gradient(135deg,var(--accent),var(--accent2))}
   label.row input[type="checkbox"]:checked::before{transform:translateX(16px)}
-  .viewer{padding:12px; border-top:1px solid var(--border); overflow:auto}
-  .viewer table{border-collapse:collapse; margin:8px 0; width:100%}
-  .viewer th, .viewer td{border:1px solid var(--border); padding:4px 8px; text-align:left}
 </style>
 </head>
 <body>
@@ -167,8 +164,7 @@ applies_to: prescribed_npo
 
     <section class="editor">
       <div id="status" class="status" style="padding:8px 10px"></div>
-      <div id="lines" class="lines" aria-label="Markdown lines"></div>
-      <div id="viewer" class="viewer" aria-label="Rendered Markdown"></div>
+      <div id="lines" class="lines" aria-label="Rendered Markdown"></div>
     </section>
   </main>
 
@@ -204,7 +200,7 @@ applies_to: prescribed_npo
   let generatedBlobUrl = null;
 
   const els = {
-    lines: qs('#lines'), status: qs('#status'), viewer: qs('#viewer'), fileInput: qs('#fileInput'), loadBtn: qs('#loadBtn'),
+    lines: qs('#lines'), status: qs('#status'), fileInput: qs('#fileInput'), loadBtn: qs('#loadBtn'),
     generateBtn: qs('#generateBtn'), downloadBtn: qs('#downloadBtn'), resetBtn: qs('#resetBtn'),
       blockName: qs('#blockName'), kvList: qs('#kvList'), addKVBtn: qs('#addKVBtn'),
       createBlockBtn: qs('#createBlockBtn'), clearPairsBtn: qs('#clearPairsBtn'), blockBar: qs('#blockBar'),
@@ -311,16 +307,9 @@ applies_to: prescribed_npo
     splitBody(originalText, front, document.getElementById('detectExisting').checked);
     renderLines();
     renderBlockBar();
-    renderPreview();
     els.downloadBtn.disabled = true;
     if (generatedBlobUrl){ URL.revokeObjectURL(generatedBlobUrl); generatedBlobUrl = null; }
     toast(`Loaded ${originalName} (${bodyLines.length} lines)`);
-  }
-
-  function renderPreview(){
-    if (!els.viewer) return;
-    const html = md.render(bodyLines.join('\n'));
-    els.viewer.innerHTML = DOMPurify.sanitize(html);
   }
 
   function renderLines(){
@@ -357,7 +346,8 @@ applies_to: prescribed_npo
 
       const code = document.createElement('div'); code.className = 'code';
       if (block){ code.style.background = colorMix(block.color, strong ? 0.18 : 0.12); code.style.borderLeftColor = block.color; }
-      code.textContent = line.length ? line : ' ';
+      const html = md.render(line.length ? line : ' ');
+      code.innerHTML = DOMPurify.sanitize(html);
 
       div.appendChild(gut); div.appendChild(code); els.lines.appendChild(div);
     });


### PR DESCRIPTION
## Summary
- Remove viewer element and preview function
- Render each Markdown line directly as sanitized HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ca15972f0833289353508cd6ab984